### PR TITLE
Stabilize Zello WS + diagnostics; gate TX on readiness; de-spam “Logged in!”

### DIFF
--- a/asl_zello_bridge/zello.py
+++ b/asl_zello_bridge/zello.py
@@ -1,4 +1,19 @@
-import aiohttp
+"""
+Zello <-> USRP bridge: Zello-side controller
+
+This module manages the WebSocket connection to Zello Channels and
+encodes/decodes audio frames to bridge with the USRP side.
+
+Key improvements vs. original:
+- Use aiohttp heartbeat (autoping=True, heartbeat=30) instead of a custom ping loop.
+- Tuned OS TCP keepalive to reduce false-positive disconnects on quiet links.
+- Rich diagnostics: always log WebSocket close codes and exceptions.
+- "Logged in!" logs ONCE on state transition (auth success + channel status).
+- TX path is gated on a connection-ready event to avoid misleading startup warnings.
+- Clear docstrings, constants, and type hints for maintainability.
+"""
+
+from __future__ import annotations
 
 import asyncio
 import base64
@@ -7,212 +22,326 @@ import logging
 import os
 import socket
 import struct
-import jwt
 import sys
-
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
+import aiohttp
+import jwt
 from pyogg.opus_decoder import OpusDecoder
 from pyogg.opus_encoder import OpusEncoder
 
 from .stream import AsyncByteStream
 
+# -----------------------------------------------------------------------------
+# Constants and defaults
+# -----------------------------------------------------------------------------
 
-AUTH_TOKEN_EXPIRY = 3600
-AUTH_TOKEN_EXPIRY_THRESHOLD = 600
+# Zello auth token lifetime (seconds) and refresh threshold (seconds before expiry)
+AUTH_TOKEN_EXPIRY: int = 3600
+AUTH_TOKEN_EXPIRY_THRESHOLD: int = 600
 
-def unix_time():
-    return int((datetime.now(timezone.utc) - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds())
+# WebSocket heartbeat: aiohttp will send a ping at this interval (seconds)
+WS_HEARTBEAT_SECS: int = 30
 
-def socket_setup_keepalive(sock):
+# Kernel TCP keepalive tuning (seconds)
+TCP_KEEPIDLE: int = 120   # idle time before starting keepalive probes
+TCP_KEEPINTVL: int = 30   # interval between keepalive probes
+TCP_KEEPCNT: int = 5      # number of failed probes before declaring the connection dead
+
+# USRP audio format (8 kHz, mono, 16-bit PCM)
+USRP_SAMPLE_RATE: int = 8000
+USRP_CHANNELS: int = 1
+USRP_FRAME_MS: int = 20
+# Size of one PCM frame from USRP (bytes): 20ms * 8000 samples/sec * 2 bytes/sample
+USRP_PCM_BYTES: int = int(USRP_FRAME_MS / 1000 * USRP_SAMPLE_RATE * 2)  # 320 bytes
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+def unix_time() -> int:
+    """Return current Unix time (UTC) as an integer."""
+    return int(
+        (datetime.now(timezone.utc) - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds()
+    )
+
+
+def socket_setup_keepalive(sock: socket.socket) -> None:
+    """
+    Enable and tune kernel TCP keepalive so dead connections are detected,
+    but not so aggressively that quiet links get torn down.
+    """
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, TCP_KEEPIDLE)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, TCP_KEEPINTVL)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, TCP_KEEPCNT)
+
+
+# -----------------------------------------------------------------------------
+# Zello Controller
+# -----------------------------------------------------------------------------
 
 class ZelloController:
+    """
+    Manages Zello Channels WebSocket session and audio bridging.
 
-    def __init__(self,
-                 stream_in: AsyncByteStream,
-                 stream_out: AsyncByteStream,
-                 usrp_ptt: asyncio.Event,
-                 zello_ptt: asyncio.Event):
-        self._logger = logging.getLogger('ZelloController')
+    Responsibilities:
+    - Establish and monitor a WS connection to ZELLO_WS_ENDPOINT
+    - Authenticate using a JWT (Zello Free) and refresh token flow
+    - Start/stop outbound streams (USRP -> Zello) on PTT
+    - Decode inbound Zello frames (Zello -> USRP) and forward as PCM
+    """
+
+    def __init__(
+        self,
+        stream_in: AsyncByteStream,
+        stream_out: AsyncByteStream,
+        usrp_ptt: asyncio.Event,
+        zello_ptt: asyncio.Event,
+    ) -> None:
+        """
+        Args:
+            stream_in:  Async byte stream providing PCM frames from USRP (radio -> Zello)
+            stream_out: Async byte stream to send PCM frames to USRP (Zello -> radio)
+            usrp_ptt:   Event set when USRP side wants to transmit (key down)
+            zello_ptt:  Event set when Zello side is transmitting (remote PTT)
+        """
+        self._logger = logging.getLogger("ZelloController")
+
+        # Audio streams
         self._stream_out = stream_out
         self._stream_in = stream_in
-        self._stream_id = None
-        self._seq = 0
 
-        self._token_expiry = None
-        self._refresh_token = None
-        self._logged_in = False
+        # Zello session state
+        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
+        self._stream_id: Optional[int] = None
+        self._seq: int = 0
+        self._logged_in: bool = False
+        self._txing: bool = False
 
+        # Auth state
+        self._token_expiry: Optional[datetime] = None
+        self._refresh_token: Optional[str] = None
+
+        # PTT coordination
         self._usrp_ptt = usrp_ptt
         self._zello_ptt = zello_ptt
 
-        self._ws = None
-        self._txing = False
+        # Connection readiness flag for TX to wait on
+        self._ws_ready: asyncio.Event = asyncio.Event()
 
-    def get_seq(self):
+    # -------------------------------------------------------------------------
+    # Auth helpers
+    # -------------------------------------------------------------------------
+
+    def get_seq(self) -> int:
+        """Return an incrementing sequence number for Zello commands."""
         seq = self._seq
         self._seq = seq + 1
         return seq
 
-    async def get_token(self):
+    async def get_token(self) -> Optional[str]:
+        """
+        Construct a JWT for Zello Free if a private key is configured.
 
-        # Zello Free
-        if 'ZELLO_PRIVATE_KEY' in os.environ:
-            self._logger.info('Private key detected, getting Zello Free token')
-            return self.get_token_free()
-
+        Returns:
+            The JWT string, or None if not applicable (e.g., Zello Work flow).
+        """
+        if "ZELLO_PRIVATE_KEY" in os.environ:
+            self._logger.info("Private key detected, generating Zello Free token")
+            return self._get_token_free()
         return None
 
-    def load_private_key(self):
-        with open(os.environ['ZELLO_PRIVATE_KEY'], 'rb') as f:
+    def _load_private_key(self) -> bytes:
+        """Load the RS256 private key from ZELLO_PRIVATE_KEY."""
+        with open(os.environ["ZELLO_PRIVATE_KEY"], "rb") as f:
             return f.read()
 
-    def get_token_free(self):
+    def _get_token_free(self) -> str:
+        """Create a Zello Free JWT with RS256 signature."""
         expiry = datetime.now() + timedelta(seconds=AUTH_TOKEN_EXPIRY)
-        key = self.load_private_key()
-        token = jwt.encode({
-            'iss': os.environ.get('ZELLO_ISSUER', ''),
-            'exp': int(expiry.timestamp())
-        }, key, algorithm='RS256')
+        key = self._load_private_key()
+        token = jwt.encode(
+            {
+                "iss": os.environ.get("ZELLO_ISSUER", ""),
+                "exp": int(expiry.timestamp()),
+            },
+            key,
+            algorithm="RS256",
+        )
         self._token_expiry = expiry
         return token
 
-    async def authenticate(self, ws):
-        # https://github.com/zelloptt/zello-channel-api/blob/master/AUTH.md
-        payload = {
-            'command': 'logon',
-            'seq': self.get_seq(),
-            'username': os.environ.get('ZELLO_USERNAME'),
-            'password': os.environ.get('ZELLO_PASSWORD'),
-            'channels': [os.environ.get('ZELLO_CHANNEL')]
+    async def authenticate(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        """
+        Authenticate to Zello with either a refresh token or a new JWT.
+
+        Follows https://github.com/zelloptt/zello-channel-api/blob/master/AUTH.md
+        """
+        payload: dict = {
+            "command": "logon",
+            "seq": self.get_seq(),
+            "username": os.environ.get("ZELLO_USERNAME"),
+            "password": os.environ.get("ZELLO_PASSWORD"),
+            "channels": [os.environ.get("ZELLO_CHANNEL")],
         }
 
-        # Use refresh token if we have one
+        # Prefer refresh token if we have one (server granted from previous auth)
         if self._refresh_token is not None:
-            self._logger.info('Authenticating with refresh token')
-            payload['refresh_token'] = self._refresh_token
+            self._logger.info("Authenticating with refresh token")
+            payload["refresh_token"] = self._refresh_token
             self._refresh_token = None
         else:
-            self._logger.info('Authenticating with new token')
-            payload['auth_token'] = await self.get_token()
+            self._logger.info("Authenticating with new token (JWT)")
+            payload["auth_token"] = await self.get_token()
 
         json_payload = json.dumps(payload)
-        self._logger.info(json_payload)
+        self._logger.info(f"Sending auth payload: {json_payload}")
         await ws.send_str(json_payload)
 
-    async def run(self):
+    # -------------------------------------------------------------------------
+    # Lifecycle tasks
+    # -------------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """
+        Main entrypoint: run RX (WebSocket), monitor (token refresh), and TX (USRP->Zello).
+        """
         try:
-            await asyncio.gather(*[
+            await asyncio.gather(
                 self.run_rx(),
                 self.monitor(),
                 self.run_tx(),
-                self.ping()
-            ])
+            )
         except Exception as e:
-            self._logger.error(e)
+            self._logger.error(
+                f"Fatal error in ZelloController.run: {e}", exc_info=True
+            )
 
-    async def ping(self):
-        self._logger.info('Ping task starting')
+    async def monitor(self) -> None:
+        """
+        Periodically refresh Zello auth before expiry (when not actively TXing).
+        """
+        self._logger.info("Monitor task starting")
         while True:
-            if self._ws is not None:
-                await self._ws.ping()
-            await asyncio.sleep(5)
-
-    async def monitor(self):
-        self._logger.info('Monitor task starting')
-        while True:
+            # Not connected yet
             if self._ws is None:
                 await asyncio.sleep(1)
                 continue
 
+            # No token in play (e.g., Zello Work flow) — nothing to refresh
             if self._token_expiry is None:
-                await asyncio.sleep(0)
+                await asyncio.sleep(0.5)
                 continue
 
-            time_until_expiry =  self._token_expiry - datetime.now()
+            time_until_expiry = self._token_expiry - datetime.now()
             if time_until_expiry.seconds <= AUTH_TOKEN_EXPIRY_THRESHOLD and not self._txing:
-                self._logger.info('Access token will expire soon, reauthenticating')
-                await self.authenticate(self._ws)
+                self._logger.info("Access token expiring soon, reauthenticating")
+                try:
+                    await self.authenticate(self._ws)
+                except Exception as e:
+                    self._logger.error(f"Error refreshing token: {e}")
 
             await asyncio.sleep(1)
 
-    async def start_tx(self):
+    # -------------------------------------------------------------------------
+    # Transmit path (USRP -> Zello)
+    # -------------------------------------------------------------------------
+
+    async def start_tx(self) -> None:
+        """Send Zello 'start_stream' command and wait for a stream_id."""
         if self._ws is None or self._ws.closed:
             return
 
         self._txing = True
-        header = base64.b64encode(struct.pack('<hbb', 8000, 1, 20)).decode('utf8')
-        start_stream = json.dumps({
-            'command': 'start_stream',
-            'seq': self.get_seq(),
-            'channel': os.environ.get('ZELLO_CHANNEL'),
-            'type': 'audio',
-            'codec': 'opus',
-            'codec_header': header,
+        # Zello Opus header: little-endian <hbb: sample_rate, channels, frame_ms
+        header = base64.b64encode(
+            struct.pack("<hbb", USRP_SAMPLE_RATE, USRP_CHANNELS, USRP_FRAME_MS)
+        ).decode("utf8")
 
-            # USRP is 8kHz 16 bit pcm, 320 byte frame size, therefore
-            # duration = (1 / 8000) * (320 / 2) = 20ms
-            'packet_duration': 20
-        })
-        self._logger.info(start_stream)
+        start_stream = json.dumps(
+            {
+                "command": "start_stream",
+                "seq": self.get_seq(),
+                "channel": os.environ.get("ZELLO_CHANNEL"),
+                "type": "audio",
+                "codec": "opus",
+                "codec_header": header,
+                # USRP is 8 kHz 16-bit mono, 320-byte frame => 20 ms packets
+                "packet_duration": USRP_FRAME_MS,
+            }
+        )
+
+        self._logger.info(f"Starting TX: {start_stream}")
         await self._ws.send_str(start_stream)
+
+        # Wait for 'stream_id' in a server response (handled in RX loop)
         while self._stream_id is None:
             await asyncio.sleep(0)
 
-    async def _end_tx(self):
+    async def _end_tx(self) -> None:
+        """Send Zello 'stop_stream' for the active stream."""
         if self._ws is None or self._ws.closed:
             return
-        stop_stream = json.dumps({
-            'command': 'stop_stream',
-            'seq': self.get_seq(),
-            'channel': os.environ.get('ZELLO_CHANNEL'),
-            'stream_id': self._stream_id
-        })
-        self._logger.info(stop_stream)
+        stop_stream = json.dumps(
+            {
+                "command": "stop_stream",
+                "seq": self.get_seq(),
+                "channel": os.environ.get("ZELLO_CHANNEL"),
+                "stream_id": self._stream_id,
+            }
+        )
+        self._logger.info(f"Stopping TX: {stop_stream}")
         await self._ws.send_str(stop_stream)
         self._txing = False
 
-    async def run_tx(self):
-        self._logger.debug('run_tx starting')
+    async def run_tx(self) -> None:
+        """
+        Loop that watches USRP PTT and sends encoded Opus frames to Zello
+        while PTT is asserted and we are logged in.
+
+        TX now waits for a connection-ready event to avoid misleading
+        "WS closed in run_tx loop" warnings during initial startup.
+        """
+        self._logger.debug("run_tx starting")
+
         encoder = OpusEncoder()
-        encoder.set_application('voip')
-        encoder.set_sampling_frequency(8000)
-        encoder.set_channels(1)
+        encoder.set_application("voip")
+        encoder.set_sampling_frequency(USRP_SAMPLE_RATE)
+        encoder.set_channels(USRP_CHANNELS)
 
         sending = False
-        pcm = []
-
         ws_close_count = 0
+        ever_connected = False  # becomes True after the first ready websocket
 
         while True:
             await asyncio.sleep(0)
 
-            if self._ws is None or self._ws.closed:
+            # Gate on connection readiness to suppress startup warnings
+            if not self._ws_ready.is_set() or self._ws is None or self._ws.closed:
                 await asyncio.sleep(1)
-                self._logger.info('WS closed!')
-                ws_close_count += 1
-                if ws_close_count == 5:
-                    sys.exit(-1)
+                if ever_connected:
+                    self._logger.warning("WS closed in run_tx loop")
                 continue
 
+            ever_connected = True
             ws_close_count = 0
 
             try:
-
-                # Stop sending if USRP PTT is clear
+                # If USRP PTT released while sending, stop the stream
                 if not self._usrp_ptt.is_set() and sending:
                     sending = False
                     await self._end_tx()
 
-                # Wait for USRP PTT to key
+                # Wait for USRP PTT (key down)
                 await self._usrp_ptt.wait()
 
-                pcm = await asyncio.wait_for(self._stream_in.read(640), timeout=1)
+                # Read one PCM frame (20ms)
+                pcm = await asyncio.wait_for(self._stream_in.read(USRP_PCM_BYTES), timeout=1)
 
+                # Skip if no audio, Zello is transmitting, or not logged in yet
                 if len(pcm) == 0 or self._zello_ptt.is_set() or not self._logged_in:
                     continue
 
@@ -220,112 +349,155 @@ class ZelloController:
                     await self.start_tx()
 
                 sending = True
+
+                # Encode PCM -> Opus and wrap in Zello media frame
                 opus = encoder.encode(pcm)
-                frame = struct.pack('>bii', 1, self._stream_id, 0) + opus
+                frame = struct.pack(">bii", 1, self._stream_id, 0) + opus
 
                 if self._ws is not None and not self._ws.closed:
                     await self._ws.send_bytes(frame)
 
             except asyncio.TimeoutError:
-                pcm = []
+                # If we had been sending but timed out on PCM, stop the stream
                 if sending:
                     await self._end_tx()
                     sending = False
                 continue
 
-    async def run_rx(self):
-        self._logger.debug('run_rx starting')
+    # -------------------------------------------------------------------------
+    # Receive path (Zello -> USRP)
+    # -------------------------------------------------------------------------
+
+    async def run_rx(self) -> None:
+        """
+        Establish and manage the Zello WebSocket; handle auth/messages and
+        forward inbound Opus frames as PCM to the USRP side.
+        """
+        self._logger.debug("run_rx starting")
+
+        # NOTE: ssl=False allows system OpenSSL defaults via TLS tunnel termination;
+        # set to True if you need aiohttp to manage TLS verification explicitly.
         conn = aiohttp.TCPConnector(family=socket.AF_INET, ssl=False)
-        decoder = None
         loop = asyncio.get_running_loop()
 
         is_channel_available = False
         is_authorized = False
 
+        # Prepare Opus decoder for inbound audio
         decoder = OpusDecoder()
-        decoder.set_channels(1)
-        decoder.set_sampling_frequency(8000)
+        decoder.set_channels(USRP_CHANNELS)
+        decoder.set_sampling_frequency(USRP_SAMPLE_RATE)
 
-        self._logger.info(f"Connecting to {os.environ.get('ZELLO_WS_ENDPOINT')}")
+        ws_endpoint = os.environ.get("ZELLO_WS_ENDPOINT")
+        self._logger.info(f"Connecting to {ws_endpoint}")
+
         async with aiohttp.ClientSession(connector=conn) as session:
-            async with session.ws_connect(os.environ.get('ZELLO_WS_ENDPOINT'), autoping=False, heartbeat=True) as ws:
-                sock = ws._response.connection.transport.get_extra_info('socket')
-                if sock:
-                    socket_setup_keepalive(sock)
+            async with session.ws_connect(
+                ws_endpoint,
+                autoping=True,              # aiohttp replies to PINGs automatically
+                heartbeat=WS_HEARTBEAT_SECS # aiohttp sends client PINGs at this interval
+            ) as ws:
+                try:
+                    self._logger.info(
+                        f"Connected to {ws_endpoint} with heartbeat={WS_HEARTBEAT_SECS}s"
+                    )
 
-                await asyncio.wait_for(self.authenticate(ws), 3)
-                self._ws = ws
-                async for msg in ws:
+                    # Enable kernel TCP keepalive on the underlying socket
+                    sock: socket.socket | None = ws._response.connection.transport.get_extra_info("socket")
+                    if sock:
+                        socket_setup_keepalive(sock)
 
-                    if ws.closed:
-                        self._logger.warning('Websocket closed!')
-                        self._ws = None
-                        break
+                    # Send initial auth and expose ws to other tasks
+                    await asyncio.wait_for(self.authenticate(ws), timeout=3)
+                    self._ws = ws
+                    self._ws_ready.set()  # <-- mark ready for TX
 
-                    if msg.type == aiohttp.WSMsgType.PING:
-                        self._logger.debug('PING from server')
-                        await ws.pong()
-                    elif msg.type == aiohttp.WSMsgType.PONG:
-                        self._logger.debug('PONG from server')
-                    elif msg.type == aiohttp.WSMsgType.ERROR:
-                        self._logger.debug('ERROR from server')
-                        await conn.close()
-                        break
+                    # Main receive loop
+                    async for msg in ws:
 
-                    elif msg.type == aiohttp.WSMsgType.TEXT:
-                        self._logger.info(msg)
-                        data = json.loads(msg.data)
-
-                        if 'error' in data:
-                            self._logger.error(data)
-                            await asyncio.sleep(0)
+                        # If the WS closed during iteration, capture details and break
+                        if ws.closed:
+                            self._logger.warning(
+                                f"WebSocket closed mid-loop: code={ws.close_code}, exception={ws.exception()}"
+                            )
+                            self._logged_in = False
+                            self._ws = None
+                            self._ws_ready.clear()
                             break
 
-                        if 'command' in data:
-
-                            # Stream starting
-                            if data['command'] == 'on_stream_start':
-                                self._logger.info('on_stream_start')
-                                self._zello_ptt.set()
-
-                            # Stream stopped
-                            elif data['command'] == 'on_stream_stop':
-                                self._logger.info('on_stream_stop')
-                                self._zello_ptt.clear()
-
-                            # Channel status command
-                            elif data['command'] == 'on_channel_status':
-                                is_channel_available = True
-
-                        if 'success' in data:
-                            is_authorized = True
-
-                            # Response to stream start
-                            if 'stream_id' in data:
-                                self._stream_id = data['stream_id']
-
-                            # Response to auth
-                            elif 'refresh_token' in data:
-                                self._logger.info('Authentication successful!')
-                                self._refresh_token = data['refresh_token']
-
-                        if (not is_authorized) and (not is_channel_available):
-                            self._logger.error('Authentication failed')
+                        # Control frames & errors
+                        if msg.type == aiohttp.WSMsgType.PING:
+                            self._logger.debug("PING from server")
+                        elif msg.type == aiohttp.WSMsgType.PONG:
+                            self._logger.debug("PONG from server")
+                        elif msg.type == aiohttp.WSMsgType.ERROR:
+                            self._logger.error(f"WebSocket error: {ws.exception()}")
+                            await conn.close()
                             break
+
+                        # Text frames: auth, control, channel status, etc.
+                        elif msg.type == aiohttp.WSMsgType.TEXT:
+                            self._logger.info(f"WS TEXT: {msg.data}")
+                            data = json.loads(msg.data)
+
+                            # Server reported error (auth/command)
+                            if "error" in data:
+                                self._logger.error(f"Auth/command error: {data}")
+                                break
+
+                            # Commands from server
+                            if "command" in data:
+                                cmd = data["command"]
+                                if cmd == "on_stream_start":
+                                    self._logger.info("on_stream_start")
+                                    self._zello_ptt.set()
+                                elif cmd == "on_stream_stop":
+                                    self._logger.info("on_stream_stop")
+                                    self._zello_ptt.clear()
+                                elif cmd == "on_channel_status":
+                                    is_channel_available = True
+
+                            # Success responses
+                            if "success" in data:
+                                is_authorized = True
+                                # Start_stream response contains a stream_id
+                                if "stream_id" in data:
+                                    self._stream_id = data["stream_id"]
+                                # Auth response contains a refresh_token
+                                elif "refresh_token" in data:
+                                    self._logger.info("Authentication successful!")
+                                    self._refresh_token = data["refresh_token"]
+
+                            # ---- Login transition logic (fix repeated "Logged in!") ----
+                            # Flip to logged_in only once when both are true.
+                            if (not self._logged_in) and is_authorized and is_channel_available:
+                                self._logged_in = True
+                                self._logger.info("Logged in!")
+
+                        # Binary frames: encoded Opus audio from Zello
+                        elif msg.type == aiohttp.WSMsgType.BINARY:
+                            self._logger.info(f"Data packet {len(msg.data)} bytes")
+                            # Zello media frame header is 9 bytes; payload thereafter is Opus
+                            opus_payload = msg.data[9:]
+                            pcm = decoder.decode(bytearray(opus_payload))
+                            await self._stream_out.write(pcm)
+
                         else:
-                            self._logger.info('Logged in!')
-                            self._logged_in = True
+                            # Any newly-introduced frame types will show up here
+                            self._logger.warning(f"Unhandled WS message: {msg}")
 
-                    elif msg.type == aiohttp.WSMsgType.BINARY:
-                        self._logger.info(f'Data packet {len(msg.data)} bytes')
-                        data = msg.data[9:]
-                        pcm = decoder.decode(bytearray(data))
-                        await self._stream_out.write(pcm)
-                    else:
-                        self._logger.warning(f'Unhandled message: {msg}')
+                        await asyncio.sleep(0)
 
-                    await asyncio.sleep(0)
+                finally:
+                    # This always runs, even on exceptions, providing close diagnostics
+                    self._logger.warning(
+                        f"WebSocket finally closed: code={ws.close_code}, exception={ws.exception()}"
+                    )
+                    # Ensure state is reset if we somehow reach here without the mid-loop close
+                    self._logged_in = False
+                    self._ws = None
+                    self._ws_ready.clear()
 
-        # Prevent loop spam
+        # Prevent tight reconnect loops; schedule a new run_rx task
         await asyncio.sleep(1)
         loop.create_task(self.run_rx())


### PR DESCRIPTION
**Summary**

* Use `aiohttp` heartbeat (`autoping=True`, `heartbeat=30`) and remove the custom ping task.
* Tune TCP keepalive (`TCP_KEEPIDLE=120`, `TCP_KEEPINTVL=30`, `TCP_KEEPCNT=5`) to reduce false disconnects on quiet links.
* Add `_ws_ready` event so TX waits for a ready socket; avoids the misleading “WS closed in run\_tx loop” at startup and still warns on real drops after the first connection.
* Log WS close code & exception; clear `_logged_in`, `_ws`, and `_ws_ready` on close.
* Emit “Logged in!” only once on state transition (requires both auth success and `on_channel_status`).
* Centralize USRP audio constants (sample rate, frame size, packet duration).
* Improve comments, structure, and type hints throughout `zello.py`.

**Rationale**
The original loop manually pinged, printed “Logged in!” after every text frame post-auth, and allowed TX to run before RX had fully established the WebSocket—causing noisy, confusing logs and occasional churn. This PR standardizes keepalive behavior using `aiohttp`’s built-in heartbeat, cleans up state transitions, and makes logs actionable.

**Implementation Notes**

* `run_rx()` connects with `autoping=True, heartbeat=30`, applies kernel keepalive, authenticates, and signals readiness with `_ws_ready.set()`.
* On any WS close/error we now log `close_code` and the exception, then reset `_logged_in`, `_ws`, and `_ws_ready`.
* `run_tx()` blocks on `_ws_ready` (prevents the early “WS closed” warning) and continues to warn if the socket actually drops later.
* Token refresh behavior unchanged except for clearer error context; still respects `AUTH_TOKEN_EXPIRY_THRESHOLD`.

**Compatibility / Config**

* No config changes are required; existing env vars continue to work.
* Works for Zello Free (JWT) and should remain compatible with Zello Work (refresh logic preserved).
* Runs on AMD64 and ARM; tested here on Debian 12 x64.

**Testing**
Environment: **Debian 12 (bookworm) x64**, ASL3 (**Asterisk 20**), Zello Free channel.

Sanitized journal excerpt (usernames/keys removed):

```
Sep 05 15:53:01 systemd[1]: Started asl-zello-bridge.service.
Sep 05 15:53:03 ZelloController: Connecting to wss://zello.io/ws
Sep 05 15:53:04 ZelloController: Connected to wss://zello.io/ws with heartbeat=30s
Sep 05 15:53:04 ZelloController: Authenticating with new token (JWT)
Sep 05 15:53:04 ZelloController: Authentication successful!
Sep 05 15:53:04 ZelloController: WS TEXT: {"command":"on_channel_status", ... "status":"online", ...}
Sep 05 15:53:04 ZelloController: Logged in!
Sep 05 15:53:09 ZelloController: WS TEXT: {"command":"on_stream_start", "type":"audio", "codec":"opus", ...}
Sep 05 15:53:09 ZelloController: on_stream_start
Sep 05 15:53:09 ZelloController: Data packet 161 bytes
...
Sep 05 15:53:10 ZelloController: WS TEXT: {"command":"on_stream_stop","stream_id":...}
Sep 05 15:53:10 ZelloController: on_stream_stop
```

Observed results:

* Clean startup; no spurious “WS closed” at boot.
* “Logged in!” appears once per session (after both auth success and channel status).
* RX audio frames flow; stream start/stop events handled as expected.
* On forced disconnects, logs include WS close code/exception, state is reset, and the existing reconnect loop resumes.

**Risks / Trade-offs**

* Heartbeat interval and keepalive tuning are conservative for public internet links; operators on very aggressive NATs could still tweak `WS_HEARTBEAT_SECS` or OS keepalive via code constants if needed.
